### PR TITLE
Add pxeless to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ RUN apt-get -y update && \
     mkdir /root/.gnupg && \
     chmod 600 /root/.gnupg
 
-WORKDIR /app
+COPY image-create.sh /app/
 
-ENTRYPOINT [ "/bin/bash" ]
+VOLUME /data
+WORKDIR /data
+
+ENTRYPOINT [ "/app/image-create.sh" ]

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ Using a fresh ISO speeds things up because there won't be as many packages to up
 - the newly added `-n`, `--code-name` flag allows you to specify an Ubuntu code-name instead of an exact version ie: `jammy`, `focal`
 
 ```bash
-docker build -t iso-generator . && \
-docker run -it --mount type=bind,source="$(pwd)",target=/app iso-generator \
-image-create.sh -a -u user-data.basic -n jammy
+docker build -t pxeless . && \
+docker run --rm --volume "$(pwd):/data" --user $(id -u):$(id -g) pxeless \
+-a -u user-data.basic -n jammy
 ```
 
 ## Credentials
@@ -109,9 +109,9 @@ mkpasswd -m sha-512 --rounds=4096 "some-password" -s "some-salt"
 
 ### Example output
 ```
-docker build -t iso-generator . && \
-docker run -it --mount type=bind,source="$(pwd)",target=/app iso-generator \
-image-create.sh -a -u user-data.basic -n jammy
+docker build -t pxeless . && \
+docker run --rm --volume "$(pwd):/data" --user $(id -u):$(id -g) pxeless \
+-a -u user-data.basic -n jammy
 ...
 ...
 ...

--- a/image-create.sh
+++ b/image-create.sh
@@ -8,7 +8,6 @@ trap cleanup SIGINT SIGTERM ERR EXIT
 export_metadata(){
 
         export TODAY=$(date +"%Y-%m-%d")
-        export SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
         export USER_DATA_FILE=''
         export META_DATA_FILE=''
         export CODE_NAME=""
@@ -17,7 +16,7 @@ export_metadata(){
         export ORIGINAL_ISO="ubuntu-original-$TODAY.iso"
         export EFI_IMAGE="ubuntu-original-$TODAY.efi"
         export MBR_IMAGE="ubuntu-original-$TODAY.mbr"
-        export SOURCE_ISO="${SCRIPT_DIR}/${ORIGINAL_ISO}"
+        export SOURCE_ISO="${ORIGINAL_ISO}"
         export DESTINATION_ISO="ubuntu-autoinstall.iso"
         export SHA_SUFFIX="${TODAY}"
         export UBUNTU_GPG_KEY_ID="843938DF228D22F7B3742BC0D94AA3F0EFE21092"
@@ -217,12 +216,12 @@ download_iso(){
 
         if [ ! -f "${SOURCE_ISO}" ]; then
                 log "🌎 Downloading ISO image for ${IMAGE_NAME} ..."
-                wget -O "${SCRIPT_DIR}/${ORIGINAL_ISO}" "${BASE_URL}/${ISO_FILE_NAME}" -q
-                log "👍 Downloaded and saved to ${SCRIPT_DIR}/${ORIGINAL_ISO}"
+                wget -O "${ORIGINAL_ISO}" "${BASE_URL}/${ISO_FILE_NAME}" -q
+                log "👍 Downloaded and saved to ${ORIGINAL_ISO}"
         else
                 log "☑️ Using existing ${SOURCE_ISO} file."
                 if [ ${GPG_VERIFY} -eq 1 ]; then
-                        if [ "${SOURCE_ISO}" != "${SCRIPT_DIR}/${ORIGINAL_ISO}" ]; then
+                        if [ "${SOURCE_ISO}" != "${ORIGINAL_ISO}" ]; then
                                 export GPG_VERIFY=0
                                 log "⚠️ Automatic GPG verification disabled. When the source ISO file is not the latest daily or release image verification cannot be performed."
                         fi
@@ -233,6 +232,7 @@ download_iso(){
 # Verify iso GPG keys
 verify_gpg(){
         if [ ${GPG_VERIFY} -eq 1 ]; then
+                export GNUPGHOME=${TMP_DIR}
                 if [ ! -f "${TMP_DIR}/SHA256SUMS-${SHA_SUFFIX}" ]; then
                         log "🌎 Downloading SHA256SUMS & SHA256SUMS.gpg files..."
                         curl -NsSL "${BASE_URL}/SHA256SUMS" -o "${TMP_DIR}/SHA256SUMS-${SHA_SUFFIX}"
@@ -396,7 +396,7 @@ reassemble_iso(){
                         -eltorito-alt-boot \
                         -e boot/grub/efi.img \
                         -no-emul-boot \
-                        -isohybrid-gpt-basdat -o "${SCRIPT_DIR}/${DESTINATION_ISO}" "${BUILD_DIR}" &>/dev/null
+                        -isohybrid-gpt-basdat -o "${DESTINATION_ISO}" "${BUILD_DIR}" &>/dev/null
         else
                 log "📦 Using El Torito method..."
                 
@@ -414,7 +414,7 @@ reassemble_iso(){
                         -eltorito-alt-boot \
                         -e '--interval:appended_partition_2:all::' \
                         -no-emul-boot \
-                        -o "${SCRIPT_DIR}/${DESTINATION_ISO}" "${BUILD_DIR}" &>/dev/null
+                        -o "${DESTINATION_ISO}" "${BUILD_DIR}" &>/dev/null
         fi
 
         log "👍 Repackaged into ${DESTINATION_ISO}"


### PR DESCRIPTION
Add pxeless aka create_image.sh to docker image as entrypoint. This will make the container image on Docker Hub easier to use.

GNUPGHOME is set to TMPDIR, which should be safe as it is created with u+rwx, to allow for non-root user to use the container.

Updated the README example accordingly.

By coincidence this also fixes #10