### PR TITLE
Avoid 50sec timeout for Focal in the lang screen

### DIFF
--- a/image-create.sh
+++ b/image-create.sh
@@ -324,6 +324,7 @@ set_kernel_autoinstall(){
                 log "🧩 Adding autoinstall parameter to isolinux..."   
                 export LEGACY_IMAGE=1
                 sed -i -e 's/---/ autoinstall  ---/g' "${BUILD_DIR}/isolinux/txt.cfg"
+                sed -i -r 's/timeout\s+[0-9]+/timeout 1/g' "${BUILD_DIR}/isolinux/isolinux.cfg"
         fi
 
         log "👍 Added parameter to UEFI and BIOS kernel command lines."


### PR DESCRIPTION
Server 20.04 gets stuck in the language selection screen for 50sec if I don't overwrite the isolinux config.

Source: https://github.com/fries/prepare-ubuntu-unattended-install-iso/blob/264e026f66c89633a7f74b5ce00a9609dded60bd/make.sh#L52-L53