### PR TITLE
Fixed dependency to /data directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,9 @@ RUN apt-get -y update && \
 	mkdir /root/.gnupg && \
 	chmod 600 /root/.gnupg
 
-COPY image-create.sh /app/
-
 VOLUME /data
 WORKDIR /data
+
+COPY image-create.sh /data
 
 ENTRYPOINT [ "/app/image-create.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ WORKDIR /data
 
 COPY image-create.sh /data
 
-ENTRYPOINT [ "/app/image-create.sh" ]
+ENTRYPOINT [ "/data/image-create.sh" ]

--- a/image-create.sh
+++ b/image-create.sh
@@ -386,7 +386,7 @@ insert_extra_files(){
 	rm -rf "${SQUASH_FS}"
 	rm -rf squashfs-root
 
-	cd /data
+	cd "$1"
 }
 
 # re-create the MD5 checksum data
@@ -480,6 +480,7 @@ die() {
 
 
 main(){
+        SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
         export_metadata
         create_tmp_dirs
 
@@ -508,7 +509,7 @@ main(){
         set_hwe_kernel
         
         if [ -n "$EXTRA_FILES_FOLDER" ]; then
-                insert_extra_files
+                insert_extra_files "$SCRIPT_DIR"
         fi
 
         if [ ${MD5_CHECKSUM} -eq 1 ]; then


### PR DESCRIPTION
Hi!
 
The command to run docker container and build image is based on the path "/data". So, if run the script locally (out of the Docker container), it is getting failed.

By applying this modification, we can run the script locally as well as container. 