### PR TITLE
[Feature] Installing offline package and customization during the image build procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ The resulting product is a fully-automated Ubuntu installer. This serves as an e
       docker run --privileged --rm --volume "$(pwd):/data" deserializeme/pxeless -a -u user-data.basic -n jammy -x /data/extras
       ```
 
+        - Running an offline installer script to customize image during build procedure. Adding a bash script as content of the `extras` directory. The script should be passed to `image-create` using  `-o` or `--offline-installer`:
+         ```bash
+         docker run --privileged --rm --volume "$(pwd):/data" deserializeme/pxeless -a -u user-data.basic -n jammy -x /data/extras -o installer-sample.sh
+        ```
+
 
 4. Writing your ISO to a USB drive
 

--- a/extras/installer-sample.sh
+++ b/extras/installer-sample.sh
@@ -4,11 +4,14 @@
 echo 'nameserver 8.8.8.8' > /etc/resolv.conf
 
 apt update
+# List of packages to be installed during build
 apt install -y \
         vim \
         htop
-echo ' ' > /etc/resolv.conf
+        
 apt clean
+
+echo ' ' > /etc/resolv.conf
 
 history -c
 exit

--- a/extras/installer-sample.sh
+++ b/extras/installer-sample.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Ref: https://dev.to/otomato_io/how-to-create-custom-debian-based-iso-4g37
+
+echo 'nameserver 8.8.8.8' > /etc/resolv.conf
+
+apt update
+apt install -y \
+        vim \
+        htop
+echo ' ' > /etc/resolv.conf
+apt clean
+
+history -c
+exit


### PR DESCRIPTION
According to https://github.com/cloudymax/pxeless/issues/30 , I have added a new switch to support running a bash script during image building procedure.

The new feature can be used to install debian packages during build, so the final image doesn't need access to Internet to install packages.

Also the offline-script can be used to do more customization during build.

I hope this feature would be useful to merge :) 